### PR TITLE
feat: Added and updated Auth screens

### DIFF
--- a/src/assets/chevron-left.svg
+++ b/src/assets/chevron-left.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="9.274" height="10.354" viewBox="0 0 9.274 10.354">
-    <path data-name="Path 91577" d="m8572.015-13882-6.015 4.024 6.015 3.572" transform="translate(-8564.127 13883.387)" style="fill:none;stroke:#c6c6c6;stroke-linecap:round;stroke-width:2px"/>
+<svg width="5" height="9" viewBox="0 0 5 9" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3.3422 0.640274C3.64164 0.294467 4.17173 0.275757 4.49481 0.599591C4.78131 0.88677 4.80273 1.34463 4.54429 1.6573L2.19464 4.5L4.54808 7.38088C4.80352 7.69357 4.77664 8.14986 4.48625 8.43039C4.16593 8.73983 3.6515 8.71692 3.35995 8.38023L-1.96701e-07 4.5L3.3422 0.640274Z" fill="#6E6A65"/>
 </svg>

--- a/src/ui/components/auth/Auth.scss
+++ b/src/ui/components/auth/Auth.scss
@@ -121,6 +121,8 @@ form .input-field-inset:not(.input-field-inset-focused) input {
 		line-height: 1.6;
 		color: var(--color-command);
 		flex: 1;
+		max-height: 80px;
+		overflow-y: scroll;
 		.hljs-string {
 			color: inherit;
 		}

--- a/src/ui/components/auth/Auth.scss
+++ b/src/ui/components/auth/Auth.scss
@@ -60,8 +60,7 @@
 	.link {
 		color: var(--color-link);
 		cursor: pointer;
-
-		&.add-new-user {
+		&:hover {
 			text-decoration: underline;
 		}
 	}
@@ -84,6 +83,10 @@ form .input-field-inset:not(.input-field-inset-focused) input {
 			text-decoration: underline;
 		}
 	}
+
+	img.back-chevron {
+		margin-inline-end: 6px;
+	}
 }
 
 .command-container {
@@ -96,25 +99,37 @@ form .input-field-inset:not(.input-field-inset-focused) input {
 	border-radius: 6px;
 
 	.clipboard-btn-container {
-		height: fit-content;
-		padding: 5px;
+		height: 24px;
+		min-width: 24px;
 		border-radius: 50%;
 		transition: 0.1s all ease-in-out;
+		cursor: pointer;
 
 		&:hover {
-			background: lightgray;
+			background: rgba(217, 217, 217, 0.6);
 		}
 
 		.clipboard-icon {
-			cursor: pointer;
 			width: 12px;
+			height: 14px;
 		}
 	}
 
 	code.command {
-		word-break: break-all;
+		word-break: break-word;
 		font-size: 13px;
 		line-height: 1.6;
 		color: var(--color-command);
+		flex: 1;
+		.hljs-string {
+			color: inherit;
+		}
+	}
+
+	.tooltip-container {
+		height: fit-content;
+		.tooltip-container__popup {
+			padding: 3px 8px;
+		}
 	}
 }

--- a/src/ui/components/auth/Auth.scss
+++ b/src/ui/components/auth/Auth.scss
@@ -13,6 +13,8 @@
  * under the License.
  */
 
+@import "../../styles/mixin.scss";
+
 .auth-container {
 	height: 100vh;
 	width: 100vw;
@@ -94,7 +96,7 @@ form .input-field-inset:not(.input-field-inset-focused) input {
 	display: flex;
 	padding-block: 6px;
 	padding-inline: 8px 4px;
-	column-gap: 12px;
+	@include gap-horizontal(12px);
 	border: 1px solid var(--color-border-command);
 	border-radius: 6px;
 

--- a/src/ui/components/auth/Auth.scss
+++ b/src/ui/components/auth/Auth.scss
@@ -14,33 +14,107 @@
  */
 
 .auth-container {
-  height: 100vh;
-  width: 100vw;
-  display: flex;
-  flex-flow: column;
-  justify-content: center;
-  align-items: center;
-  background-position: top center;
-  background-repeat: no-repeat;
-  background-size: cover;
-  background-image: var(--auth-background-portrait);
-  @media only screen and (min-width: 600px) {
-    background-image: var(--auth-background);
-  }
+	height: 100vh;
+	width: 100vw;
+	display: flex;
+	flex-flow: column;
+	justify-content: center;
+	align-items: center;
+	background-position: top center;
+	background-repeat: no-repeat;
+	background-size: cover;
+	background-image: var(--auth-background-portrait);
+	@media only screen and (min-width: 600px) {
+		background-image: var(--auth-background);
+	}
 }
 
 .auth-container .block-container {
-  max-width: 320px;
-  margin: 32px auto;
-  @media only screen and (min-width: 600px) {
-    max-width: 416px;
-  }
+	max-width: 320px;
+	margin: 32px auto;
+	@media only screen and (min-width: 600px) {
+		max-width: 416px;
+	}
 }
 
-.auth-container .text-title {
-  margin-bottom: 8px;
+.auth-container {
+	.text-title {
+		margin-bottom: 8px;
+	}
+
+	label {
+		font-size: 14px;
+		font-weight: 500;
+		margin-block-end: 7px;
+		display: inline-block;
+	}
 }
 
-.auth-container > * > p {
-  margin-bottom: 16px;
+.block-container {
+	hr {
+		margin-block: 24px;
+		border-bottom: none;
+		border-top: 1px solid rgb(221, 221, 221);
+	}
+
+	.link {
+		color: var(--color-link);
+		cursor: pointer;
+
+		&.add-new-user {
+			text-decoration: underline;
+		}
+	}
+}
+
+form .input-field-inset:not(.input-field-inset-focused) input {
+	background-color: var(--color-input-unfocused);
+}
+
+.cta-container {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+
+	.secondary-cta-btn {
+		font-family: inherit;
+		font-size: 14px;
+
+		&.forgot-btn {
+			text-decoration: underline;
+		}
+	}
+}
+
+.command-container {
+	margin-block: 24px 18px;
+	display: flex;
+	padding-block: 6px;
+	padding-inline: 8px 4px;
+	column-gap: 12px;
+	border: 1px solid var(--color-border-command);
+	border-radius: 6px;
+
+	.clipboard-btn-container {
+		height: fit-content;
+		padding: 5px;
+		border-radius: 50%;
+		transition: 0.1s all ease-in-out;
+
+		&:hover {
+			background: lightgray;
+		}
+
+		.clipboard-icon {
+			cursor: pointer;
+			width: 12px;
+		}
+	}
+
+	code.command {
+		word-break: break-all;
+		font-size: 13px;
+		line-height: 1.6;
+		color: var(--color-command);
+	}
 }

--- a/src/ui/components/auth/Auth.tsx
+++ b/src/ui/components/auth/Auth.tsx
@@ -35,6 +35,7 @@ const Auth: React.FC<{
 			case "sign-in":
 				return (
 					<SignIn
+						onCreateNewUserClick={() => setContentMode("sign-up")}
 						onForgotPasswordBtnClick={() => setContentMode("forgot-password")}
 						onSuccess={props.onSuccess}
 					/>

--- a/src/ui/components/auth/SignInContent.tsx
+++ b/src/ui/components/auth/SignInContent.tsx
@@ -65,6 +65,13 @@ const SignInContent: React.FC<SignInContentProps> = ({
 		e.preventDefault();
 		// setApiKeyFieldError("");
 
+		if (!email) {
+			setEmailError("Email cannot be empty");
+		}
+		if (!password) {
+			setPasswordError("Password cannot be empty");
+		}
+
 		// if (apiKey !== null && apiKey !== undefined && apiKey.length > 0) {
 		// 	void validateKey();
 		// } else {

--- a/src/ui/components/auth/SignInContent.tsx
+++ b/src/ui/components/auth/SignInContent.tsx
@@ -1,0 +1,120 @@
+import React, { useState } from "react";
+import { UNAUTHORISED_STATUS } from "../../../constants";
+import { fetchData, getApiUrl, getImageUrl } from "../../../utils";
+import InputField from "../inputField/InputField";
+
+interface SignInContentProps {
+	onSuccess: () => void;
+	onForgotPasswordBtnClick: () => void;
+}
+
+const SignInContent: React.FC<SignInContentProps> = ({ onSuccess, onForgotPasswordBtnClick }): JSX.Element => {
+	const [isLoading, setIsLoading] = useState<boolean>(false);
+
+	const [email, setEmail] = useState("");
+	const [password, setPassword] = useState("");
+	const [emailError, setEmailError] = useState("");
+	const [passwordError, setPasswordError] = useState("");
+
+	const validateKey = async () => {
+		setIsLoading(true);
+		const response = await fetchData({
+			url: getApiUrl("/api/key/validate"),
+			method: "POST",
+			config: {
+				headers: {
+					// authorization: `Bearer ${apiKey}`,
+				},
+			},
+		});
+
+		const body = await response.json();
+
+		if (response.status === 200 && body.status === "OK") {
+			// localStorageHandler.setItem(StorageKeys.API_KEY, apiKey);
+			onSuccess();
+		} else if (response.status === UNAUTHORISED_STATUS) {
+			// setApiKeyFieldError("Invalid API Key");
+		} else {
+			// setApiKeyFieldError("Something went wrong");
+		}
+
+		setIsLoading(false);
+	};
+
+	const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+		e.preventDefault();
+		// setApiKeyFieldError("");
+
+		// if (apiKey !== null && apiKey !== undefined && apiKey.length > 0) {
+		// 	void validateKey();
+		// } else {
+		// 	setApiKeyFieldError("API Key field cannot be empty");
+		// }
+	};
+
+	const handleEmailFieldChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		setEmail(e.target.value);
+	};
+
+	const handlePasswordFieldChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		setPassword(e.target.value);
+	};
+
+	return (
+		<div>
+			<h2 className="api-key-form-title text-title">Sign In</h2>
+			<p className="text-small text-label">
+				More members required? <span className="add-new-user link">Add a new user</span>
+			</p>
+
+			<hr />
+
+			<form
+				className="api-key-form"
+				onSubmit={handleSubmit}>
+				<label>Email</label>
+				<InputField
+					handleChange={handleEmailFieldChange}
+					name="email"
+					type="email"
+					error={emailError}
+					value={email}
+					placeholder=""
+				/>
+
+				<label>Password</label>
+				<InputField
+					handleChange={handlePasswordFieldChange}
+					name="password"
+					type="password"
+					error={passwordError}
+					value={password}
+					placeholder=""
+				/>
+
+				<div className="cta-container">
+					<button
+						className="button"
+						type="submit"
+						disabled={isLoading}>
+						<span>Sign In</span>{" "}
+						<img
+							src={getImageUrl("right_arrow_icon.svg")}
+							alt="Auth Page"
+						/>
+					</button>
+
+					<button
+						onClick={onForgotPasswordBtnClick}
+						className="flat secondary-cta-btn  forgot-btn bold-400"
+						role="button">
+						Forgot Password?
+					</button>
+				</div>
+			</form>
+		</div>
+	);
+};
+
+export default SignInContent;

--- a/src/ui/components/auth/SignInContent.tsx
+++ b/src/ui/components/auth/SignInContent.tsx
@@ -1,3 +1,17 @@
+/* Copyright (c) 2022, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ * This software is licensed under the Apache License, Version 2.0 (the
+ * "License") as published by the Apache Software Foundation.
+ *
+ * You may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 import React, { useState } from "react";
 import { UNAUTHORISED_STATUS } from "../../../constants";
 import { fetchData, getApiUrl, getImageUrl } from "../../../utils";
@@ -5,10 +19,15 @@ import InputField from "../inputField/InputField";
 
 interface SignInContentProps {
 	onSuccess: () => void;
+	onCreateNewUserClick: () => void;
 	onForgotPasswordBtnClick: () => void;
 }
 
-const SignInContent: React.FC<SignInContentProps> = ({ onSuccess, onForgotPasswordBtnClick }): JSX.Element => {
+const SignInContent: React.FC<SignInContentProps> = ({
+	onSuccess,
+	onCreateNewUserClick,
+	onForgotPasswordBtnClick,
+}): JSX.Element => {
 	const [isLoading, setIsLoading] = useState<boolean>(false);
 
 	const [email, setEmail] = useState("");
@@ -65,7 +84,13 @@ const SignInContent: React.FC<SignInContentProps> = ({ onSuccess, onForgotPasswo
 		<div>
 			<h2 className="api-key-form-title text-title">Sign In</h2>
 			<p className="text-small text-label">
-				More members required? <span className="add-new-user link">Add a new user</span>
+				More members required?{" "}
+				<span
+					role={"button"}
+					onClick={onCreateNewUserClick}
+					className="add-new-user link">
+					Add a new user
+				</span>
 			</p>
 
 			<hr />

--- a/src/ui/components/auth/SignUpOrResetPasswordContent.tsx
+++ b/src/ui/components/auth/SignUpOrResetPasswordContent.tsx
@@ -88,7 +88,7 @@ const SignUpOrResetPasswordContent: React.FC<ISignUpOrResetPasswordContentProps>
 			<p className="text-small text-label">{subtitle}</p>
 			<div className="command-container">
 				<code
-					className="command bold-400"
+					className="command with-thin-scrollbar bold-400"
 					dangerouslySetInnerHTML={{
 						__html: highlightedCode.value,
 					}}

--- a/src/ui/components/auth/SignUpOrResetPasswordContent.tsx
+++ b/src/ui/components/auth/SignUpOrResetPasswordContent.tsx
@@ -16,7 +16,7 @@ import HighlightJS from "highlight.js";
 import BashHighlight from "highlight.js/lib/languages/bash";
 import { useEffect, useState } from "react";
 import { getImageUrl } from "../../../utils";
-import TooltipContainer from "../tooltip/tooltip";
+import CopyText from "../copyText/CopyText";
 import { ContentMode } from "./types";
 
 interface ISignUpOrResetPasswordContentProps {
@@ -93,23 +93,9 @@ const SignUpOrResetPasswordContent: React.FC<ISignUpOrResetPasswordContentProps>
 						__html: highlightedCode.value,
 					}}
 				/>
-				<TooltipContainer
-					showTooltip={showCopiedTooltip}
-					tooltipWidth={65}
-					trigger="click"
-					tooltip={"Copied!"}
-					position="bottom">
-					<div
-						onClick={copyClickHandler}
-						role={"button"}
-						className="clipboard-btn-container flex-center-x flex-center-y">
-						<img
-							className="clipboard-icon"
-							alt="Copy to clipboard"
-							src={getImageUrl("copy.svg")}
-						/>
-					</div>
-				</TooltipContainer>
+				<div>
+					<CopyText showChild={false}>{command}</CopyText>
+				</div>
 			</div>
 			<div className="cta-container">
 				<div />

--- a/src/ui/components/auth/SignUpOrResetPasswordContent.tsx
+++ b/src/ui/components/auth/SignUpOrResetPasswordContent.tsx
@@ -98,7 +98,7 @@ const SignUpOrResetPasswordContent: React.FC<ISignUpOrResetPasswordContentProps>
 					tooltipWidth={65}
 					trigger="click"
 					tooltip={"Copied!"}
-					position="right">
+					position="bottom">
 					<div
 						onClick={copyClickHandler}
 						role={"button"}

--- a/src/ui/components/auth/SignUpOrResetPasswordContent.tsx
+++ b/src/ui/components/auth/SignUpOrResetPasswordContent.tsx
@@ -1,0 +1,89 @@
+import { getImageUrl } from "../../../utils";
+import { ContentMode } from "./types";
+
+interface ISignUpOrResetPasswordContentProps {
+	contentMode: Exclude<ContentMode, "sign-in">;
+	onBack: () => void;
+}
+
+const SignUpOrResetPasswordContent: React.FC<ISignUpOrResetPasswordContentProps> = ({
+	contentMode,
+	onBack,
+}: ISignUpOrResetPasswordContentProps): JSX.Element => {
+	const getTextContent = () => {
+		switch (contentMode) {
+			case "sign-up":
+				return {
+					title: "Sign Up",
+					subtitle: "Insert the below command in your backend configuration to create a new user",
+				};
+			case "forgot-password":
+				return {
+					title: "Reset your password",
+					subtitle: "Run the below command in your terminal",
+				};
+			default:
+				throw Error("No content found for the prop!");
+		}
+	};
+
+	const getBottomCTAContent = () => {
+		switch (contentMode) {
+			case "sign-up":
+				break;
+			case "forgot-password":
+				break;
+			default:
+				break;
+		}
+	};
+
+	const { title, subtitle } = getTextContent();
+
+	const command =
+		"https://1ac25a511cec847d6570cjdf1ac25a511cec847d6570cb1ac25a511cec847d6570cb1ac25a511cec847d6570cb1ac25a511cec847d6570cb1ac25a511cec847";
+
+	const copyClickHandler = async () => {
+		try {
+			await navigator.clipboard.writeText(command);
+		} catch (error) {
+			throw Error("failed to copy the command");
+		}
+	};
+
+	return (
+		<section>
+			<h2 className="api-key-form-title text-title">{title}</h2>
+			<p className="text-small text-label">{subtitle}</p>
+			<div className="command-container">
+				<code className="command bold-400">{command}</code>
+				<div className="clipboard-btn-container">
+					<img
+						onClick={copyClickHandler}
+						role={"button"}
+						className="clipboard-icon"
+						alt="Copy to clipboard"
+						src={getImageUrl("copy.svg")}
+					/>
+				</div>
+			</div>
+			<div className="cta-container">
+				<div />
+
+				<span>Account exists ? Sign In</span>
+				<button
+					className="flat secondary-cta-btn bold-400"
+					onClick={onBack}>
+					{" "}
+					<img
+						alt="Go back"
+						src={getImageUrl("chevron-left.svg")}
+					/>{" "}
+					Back
+				</button>
+			</div>
+		</section>
+	);
+};
+
+export default SignUpOrResetPasswordContent;

--- a/src/ui/components/auth/types.ts
+++ b/src/ui/components/auth/types.ts
@@ -1,0 +1,1 @@
+export type ContentMode = "sign-in" | "sign-up" | "forgot-password";

--- a/src/ui/components/copyText/CopyText.tsx
+++ b/src/ui/components/copyText/CopyText.tsx
@@ -19,10 +19,11 @@ import Toast, { TOAST_DEFAULT_DURATION } from "../toast/toast";
 import "./CopyText.scss";
 
 type CopyTextProps = {
+	showChild?: boolean;
 	children: string;
 };
 
-export const CopyText: React.FC<CopyTextProps> = ({ children }: CopyTextProps) => {
+export const CopyText: React.FC<CopyTextProps> = ({ showChild = true, children }: CopyTextProps) => {
 	const alertWidth = 80;
 	const copyBoxRef = useRef<HTMLDivElement>(null);
 	const [isCopied, setIsCopied] = useState<boolean>(false);
@@ -64,7 +65,7 @@ export const CopyText: React.FC<CopyTextProps> = ({ children }: CopyTextProps) =
 			ref={copyBoxRef}
 			className={`copy-text ${isCopied ? "copy-text-copied" : ""}`}
 			onMouseEnter={() => setIsCopied(false)}>
-			<span className="copy-text-text">{children}</span>
+			{showChild && <span className="copy-text-text">{children}</span>}
 			<span
 				className="copy-text-action"
 				onClick={copyClick}>

--- a/src/ui/components/tooltip/tooltip.tsx
+++ b/src/ui/components/tooltip/tooltip.tsx
@@ -23,8 +23,6 @@ type TooltipProps = TooltipBaseProps & {
 	trigger?: TooltipTrigger;
 	/** Tooltip content */
 	tooltip: ReactNode;
-	/** Control the tooltip's visibility from the parent */
-	showTooltip?: boolean;
 };
 
 /** The element that will pop out when the `TooltipContainer` is receiving  `TooltipTrigger`*/
@@ -55,10 +53,6 @@ export const TooltipContainer: FC<TooltipProps> = (props) => {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const { trigger = "hover", children, tooltip, position, tooltipWidth = DEFAULT_TOOLTIP_WIDTH } = props;
 	const [isTooltipShown, setIsTooltipShown] = useState<boolean>(false);
-
-	useEffect(() => {
-		setIsTooltipShown(Boolean(props.showTooltip));
-	}, [props.showTooltip]);
 
 	const handleTooltipTrigger = useCallback(
 		(triggerType: TooltipTrigger) => {

--- a/src/ui/components/tooltip/tooltip.tsx
+++ b/src/ui/components/tooltip/tooltip.tsx
@@ -23,6 +23,8 @@ type TooltipProps = TooltipBaseProps & {
 	trigger?: TooltipTrigger;
 	/** Tooltip content */
 	tooltip: ReactNode;
+	/** Control the tooltip's visibility from the parent */
+	showTooltip?: boolean;
 };
 
 /** The element that will pop out when the `TooltipContainer` is receiving  `TooltipTrigger`*/
@@ -53,6 +55,10 @@ export const TooltipContainer: FC<TooltipProps> = (props) => {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const { trigger = "hover", children, tooltip, position, tooltipWidth = DEFAULT_TOOLTIP_WIDTH } = props;
 	const [isTooltipShown, setIsTooltipShown] = useState<boolean>(false);
+
+	useEffect(() => {
+		setIsTooltipShown(Boolean(props.showTooltip));
+	}, [props.showTooltip]);
 
 	const handleTooltipTrigger = useCallback(
 		(triggerType: TooltipTrigger) => {

--- a/src/ui/styles/index.css
+++ b/src/ui/styles/index.css
@@ -24,7 +24,7 @@ body {
 }
 
 code {
-	font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
+	font-family: Menlo, source-code-pro, Monaco, Consolas, "Courier New", monospace;
 }
 
 * {

--- a/src/ui/styles/uikit.scss
+++ b/src/ui/styles/uikit.scss
@@ -395,7 +395,7 @@ button.link,
 		&.popup_right::before {
 			border-right-color: var(--color-white);
 			border-left: none;
-			left: 0px;
+			left: 0.5px;
 			top: 50%;
 			transform: translateX(-100%) translateY(-50%);
 		}
@@ -418,6 +418,16 @@ button.link,
 
 .center {
 	text-align: center;
+}
+
+.flex-center-x {
+	display: flex;
+	justify-content: center;
+}
+
+.flex-center-y {
+	display: flex;
+	align-items: center;
 }
 
 $fontWeights: 400, 500, 600, 700;

--- a/src/ui/styles/uikit.scss
+++ b/src/ui/styles/uikit.scss
@@ -395,7 +395,7 @@ button.link,
 		&.popup_right::before {
 			border-right-color: var(--color-white);
 			border-left: none;
-			left: 0.5px;
+			left: 0;
 			top: 50%;
 			transform: translateX(-100%) translateY(-50%);
 		}

--- a/src/ui/styles/uikit.scss
+++ b/src/ui/styles/uikit.scss
@@ -430,6 +430,15 @@ button.link,
 	align-items: center;
 }
 
+.with-thin-scrollbar {
+	&::-webkit-scrollbar {
+		width: 5px;
+	}
+	&::-webkit-scrollbar-thumb {
+		box-shadow: inset 0 0 6px var(--color-loader-placeholder-bg);
+	}
+}
+
 $fontWeights: 400, 500, 600, 700;
 
 @each $weight in $fontWeights {

--- a/src/ui/styles/uikit.scss
+++ b/src/ui/styles/uikit.scss
@@ -419,3 +419,11 @@ button.link,
 .center {
 	text-align: center;
 }
+
+$fontWeights: 400, 500, 600, 700;
+
+@each $weight in $fontWeights {
+	.bold-#{$weight} {
+		font-weight: $weight !important;
+	}
+}

--- a/src/ui/styles/variables.css
+++ b/src/ui/styles/variables.css
@@ -41,7 +41,7 @@ body {
 	--color-border-error: rgb(239, 121, 119);
 	--color-border-info: rgb(151, 189, 250);
 	--color-border-success: rgb(73, 200, 153);
-	--color-border-command: rgba(221, 221, 221);
+	--color-border-command: rgb(221, 221, 221);
 
 	/* Text Colors */
 	--color-secondary-text: rgb(110, 106, 101); /* Below title, table headers, placeholders etc */
@@ -49,7 +49,7 @@ body {
 	--color-info: rgb(31, 90, 219);
 	--color-success: rgb(4, 84, 62);
 	--color-link: rgb(0, 118, 255);
-	--color-command: rgba(214, 80, 120);
+	--color-command: rgb(214, 80, 120);
 
 	/* Recipe Pill Colors */
 	--color-emailpassword-bg: rgb(221, 252, 247);

--- a/src/ui/styles/variables.css
+++ b/src/ui/styles/variables.css
@@ -34,18 +34,22 @@ body {
 	--color-success-bg: rgb(241, 250, 247);
 	--color-success-shadow: rgba(4, 84, 62, 0.16);
 	--color-link: rgb(0, 122, 255);
+	--color-input-unfocused: rgb(250, 250, 250);
 
 	/* Border Colors */
 	--color-border: rgb(229, 229, 229);
 	--color-border-error: rgb(239, 121, 119);
 	--color-border-info: rgb(151, 189, 250);
 	--color-border-success: rgb(73, 200, 153);
+	--color-border-command: rgba(221, 221, 221);
 
 	/* Text Colors */
 	--color-secondary-text: rgb(110, 106, 101); /* Below title, table headers, placeholders etc */
 	--color-error: rgb(158, 37, 38);
 	--color-info: rgb(31, 90, 219);
 	--color-success: rgb(4, 84, 62);
+	--color-link: rgb(0, 118, 255);
+	--color-command: rgba(214, 80, 120);
 
 	/* Recipe Pill Colors */
 	--color-emailpassword-bg: rgb(221, 252, 247);


### PR DESCRIPTION
## Summary of change
Added the Sign In, Sign Up and Forget Password UI screens

### Problem Statement

(A few sentences about why this change is being made)
Because the previous method of logging in is outdated.

### Summary of solution
Implemented the code corresponding to the Figma designs (mentioned in #1003)
(Overview of how the problem is solved by this PR)

## Related issues 

-   Link to issue: Auth screens for user management dashboard #1003

## Test Plan

### Tested on all primary browsers for:

-   Chrome
    -   [x] Desktop
    -   [ ] Mobile
    -   [ ] Tablet
-   Safari
    -   [ ] Desktop
    -   [ ] Mobile
    -   [ ] Tablet
-   Firefox
    -   [x] Desktop
    -   [ ] Mobile
    -   [ ] Tablet
-   (Optional) Tested on Safari 12 (Physical or emulator)
    -   [ ] iPad
    -   [ ] iPhone
-   (Optional) Tested on physical mobile and tablet device for:
    -   [ ] Android
    -   [ ] iOS (including iPadOS)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates

-   [ ] Changelog has been updated
-   [ ] Changes to the version if needed
    -   In `package.json`
    -   In `package-lock.json`
    -   In `src/version.ts`
-   [ ] Had run `npm run build`
-   [ ] Had installed and ran the pre-commit hook

## Remaining TODOs for this PR

-   [ ] Item1
-   [ ] Item2
